### PR TITLE
app.exec() - run system shell command

### DIFF
--- a/androidjs/src/main/java/com/android/js/api/App.java
+++ b/androidjs/src/main/java/com/android/js/api/App.java
@@ -5,10 +5,10 @@ import android.os.Environment;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
-import java.util.HashMap;
 import java.io.InputStreamReader;
 import java.io.BufferedReader;
+import org.json.JSONObject;
+import org.json.JSONException;
 
 import static android.os.Environment.DIRECTORY_ALARMS;
 import static android.os.Environment.DIRECTORY_DCIM;
@@ -19,8 +19,6 @@ import static android.os.Environment.DIRECTORY_NOTIFICATIONS;
 import static android.os.Environment.DIRECTORY_PICTURES;
 import static android.os.Environment.DIRECTORY_PODCASTS;
 import static android.os.Environment.DIRECTORY_RINGTONES;
-
-import static com.android.js.other.Utils.exec;
 
 public class App {
     private Activity activity;
@@ -65,21 +63,21 @@ public class App {
         }
     }
 
-    public static Map<String, String> exec(String[] cmdarray) { 
-        Map<String, String> result = new HashMap<String, String>();
+   public String exec(String[] cmdarray) throws JSONException { 
+        JSONObject result = new JSONObject();
         try { 
             Process process = Runtime.getRuntime().exec(cmdarray);
             process.waitFor();
-            result.put("status", String.valueOf(process.exitValue()));
+            result.put("status", process.exitValue());
             result.put("stdout", readStream(process.getInputStream()));
             result.put("stderr", readStream(process.getErrorStream()));
         } catch (Exception e) {
             result.put("error", e.getMessage());
         }
-        return result;
+        return result.toString();
     }
 
-    private static String readStream(InputStream stream) throws IOException {
+    private String readStream(InputStream stream) throws IOException {
         BufferedReader reader = new BufferedReader(
             new InputStreamReader(stream));
         StringBuilder content = new StringBuilder(); 

--- a/androidjs/src/main/java/com/android/js/api/App.java
+++ b/androidjs/src/main/java/com/android/js/api/App.java
@@ -87,6 +87,6 @@ public class App {
         while((s = reader.readLine()) != null) {
             content.append(s + "\n");
         }
-        return content.toString();
+        return content.toString().trim();
     }
 }

--- a/androidjs/src/main/java/com/android/js/api/App.java
+++ b/androidjs/src/main/java/com/android/js/api/App.java
@@ -3,6 +3,13 @@ package com.android.js.api;
 import android.app.Activity;
 import android.os.Environment;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+
 import static android.os.Environment.DIRECTORY_ALARMS;
 import static android.os.Environment.DIRECTORY_DCIM;
 import static android.os.Environment.DIRECTORY_DOWNLOADS;
@@ -12,6 +19,8 @@ import static android.os.Environment.DIRECTORY_NOTIFICATIONS;
 import static android.os.Environment.DIRECTORY_PICTURES;
 import static android.os.Environment.DIRECTORY_PODCASTS;
 import static android.os.Environment.DIRECTORY_RINGTONES;
+
+import static com.android.js.other.Utils.exec;
 
 public class App {
     private Activity activity;
@@ -54,5 +63,30 @@ public class App {
         } else {
             return "-1";
         }
+    }
+
+    public static Map<String, String> exec(String[] cmdarray) { 
+        Map<String, String> result = new HashMap<String, String>();
+        try { 
+            Process process = Runtime.getRuntime().exec(cmdarray);
+            process.waitFor();
+            result.put("status", String.valueOf(process.exitValue()));
+            result.put("stdout", readStream(process.getInputStream()));
+            result.put("stderr", readStream(process.getErrorStream()));
+        } catch (Exception e) {
+            result.put("error", e.getMessage());
+        }
+        return result;
+    }
+
+    private static String readStream(InputStream stream) throws IOException {
+        BufferedReader reader = new BufferedReader(
+            new InputStreamReader(stream));
+        StringBuilder content = new StringBuilder(); 
+        String s;
+        while((s = reader.readLine()) != null) {
+            content.append(s + "\n");
+        }
+        return content.toString();
     }
 }

--- a/androidjs/src/main/java/com/android/js/api/App.java
+++ b/androidjs/src/main/java/com/android/js/api/App.java
@@ -64,9 +64,9 @@ public class App {
         }
     }
 
-   public String exec(String[] cmdarray) throws JSONException { 
+   public String exec(String[] cmdarray) throws JSONException {
         JSONObject result = new JSONObject();
-        try { 
+        try {
             Process process = Runtime.getRuntime().exec(cmdarray, null,
                 new File(this.activity.getFilesDir().getPath()));
             process.waitFor();
@@ -82,11 +82,13 @@ public class App {
     private String readStream(InputStream stream) throws IOException {
         BufferedReader reader = new BufferedReader(
             new InputStreamReader(stream));
-        StringBuilder content = new StringBuilder(); 
+        StringBuilder content = new StringBuilder();
+        int cnt = 0;
         String s;
         while((s = reader.readLine()) != null) {
             content.append(s + "\n");
+            cnt++;
         }
-        return content.toString().trim();
+        return cnt == 1 ? content.toString().trim() : content.toString();
     }
 }

--- a/androidjs/src/main/java/com/android/js/api/App.java
+++ b/androidjs/src/main/java/com/android/js/api/App.java
@@ -3,6 +3,7 @@ package com.android.js.api;
 import android.app.Activity;
 import android.os.Environment;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -66,7 +67,8 @@ public class App {
    public String exec(String[] cmdarray) throws JSONException { 
         JSONObject result = new JSONObject();
         try { 
-            Process process = Runtime.getRuntime().exec(cmdarray);
+            Process process = Runtime.getRuntime().exec(cmdarray, null,
+                new File(this.activity.getFilesDir().getPath()));
             process.waitFor();
             result.put("status", process.exitValue());
             result.put("stdout", readStream(process.getInputStream()));

--- a/androidjs/src/main/java/com/android/js/common/JavaWebviewBridge.java
+++ b/androidjs/src/main/java/com/android/js/common/JavaWebviewBridge.java
@@ -66,7 +66,7 @@ public class JavaWebviewBridge {
     }
 
     @JavascriptInterface
-    public static String exec(String[] cmdarray) throws JSONException { 
+    public String exec(String[] cmdarray) throws JSONException { 
         return app.exec(cmdarray);
     }
 

--- a/androidjs/src/main/java/com/android/js/common/JavaWebviewBridge.java
+++ b/androidjs/src/main/java/com/android/js/common/JavaWebviewBridge.java
@@ -66,6 +66,11 @@ public class JavaWebviewBridge {
     }
 
     @JavascriptInterface
+    public static String exec(String[] cmdarray) throws JSONException { 
+        return app.exec(cmdarray);
+    }
+
+    @JavascriptInterface
     public void initNotification(String title, String msg){
         notification.initNotification(title, msg);
     }

--- a/androidjs/src/main/java/com/android/js/react_native/api/App.java
+++ b/androidjs/src/main/java/com/android/js/react_native/api/App.java
@@ -3,6 +3,7 @@ package com.android.js.react_native.api;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import org.json.JSONException;
 
 public class App extends ReactContextBaseJavaModule {
     private ReactApplicationContext reactContext;
@@ -17,6 +18,11 @@ public class App extends ReactContextBaseJavaModule {
     @ReactMethod(isBlockingSynchronousMethod = true)
     public String getPath(String name) {
         return app.getPath(name);
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public static String exec(String[] cmdarray) throws JSONException { 
+        return app.exec(cmdarray);
     }
 
     @Override

--- a/androidjs/src/main/java/com/android/js/react_native/api/App.java
+++ b/androidjs/src/main/java/com/android/js/react_native/api/App.java
@@ -21,7 +21,7 @@ public class App extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod(isBlockingSynchronousMethod = true)
-    public static String exec(String[] cmdarray) throws JSONException { 
+    public String exec(String[] cmdarray) throws JSONException { 
         return app.exec(cmdarray);
     }
 


### PR DESCRIPTION
Ability to execute system commands and shell scripts from androidjs app.  There are quite a lot of handy utilities in android system like `am, toybox, sh, setprop, getprop, logcat` which can be use for backend processing leaving nodejs for more advanced tasks. Linux/ shell powerusers can accomplish quite a bit of using these.

Examples of usage: 

```js
// start intent using ActivitiManager
const file = 'file://' + app.getPath('downloads') + '/doc.pdf';
app.exec('am', [...'start --user 0 -a android.intent.action.VIEW -d'.split(' '), file]);

// get some prop setting
const model = app.exec('getprop', 'ro.vendor.product.model').stdout || 'unknown';

// load file
const fileContent = app.exec('toybox', ['cat', fileName]).stdout || null;
```

To chain commands, to use output redirections and other advanced stuff use shell:

```js
// count logged expression 
console.log('counter: ' + app.exec('sh', ['-c', 'logcat -d | toybox grep denied | toybox wc -l']).stdout);

// save data to file
app.exec('sh', ['-c', `echo '${myData}' > '${fileName}'`]);
```

Commands are executed in blocking synchronous manner so to process some longer lasting tasks use shell background processing.  To check if background task completed and to get results `setInterval()` method could be used: 
```js
const file = 'out.txt';
app.exec('sh', ['-c', `(sleep 10 && date > ${file}) &`]);

const checker = setInterval(() => {
  const res = app.exec('sh', ['-c', `test -s '${file}' && while read -r l; do echo $l; done < '${file}'`]);
  res.stdout && onCompleteCallback(res.stdout) && clearInterval(checker);
}, 1000);
```

It could be also accomplished in more reactive manner   realizing http server using shell and netcat (`toybox nc`) on backend side and regular xhr requests on frontend side. For an example and as a starting point see: https://github.com/AdamDanischewski/bashttpd

Some notes on it:
- bash only syntax need to be rewritten for mksh compatibility and any external command changed to `toybox` equivalents
- for secuirity listen to localhost only and use session token, without  tokens it is wide open for any local app/user
- add CORS extra response header  ''Access-Control-Allow-Origin: *" to use with xhr in androidjs context


Here is a demo app to test `app.exec()` API: [myapp-202012101200.zip](https://github.com/android-js/android-native-apis/files/5672477/myapp-202012101200.zip)


**For more see also:**
- https://android.googlesource.com/platform/system/core/+/master/shell_and_utilities/README.md
- https://landley.net/toybox/help.html
- https://linux.die.net/man/1/mksh

[Related android-js/androidjs#60, Fix  android-js/androidjs#153] i